### PR TITLE
undefined reference to `dlopen' `dlsym' and others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ F = -lrt -lm -ldl -lsndfile -lasound -pthread
 
 
 fft.bin:	$(S) $(C1D) $(H)
-	gcc -o fft.bin $(F) $(C1D)
+	gcc -o fft.bin $(C1D) $(F)
 
 clean:
 	rm -f *.bin

--- a/spi_led.c
+++ b/spi_led.c
@@ -38,7 +38,7 @@
  *
  */
 
-#import "spi_led.h"
+#include "spi_led.h"
 
 // forward declare led_data to be a struct
 


### PR DESCRIPTION
swapped $(C1D) and $(F)